### PR TITLE
Fix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ compressed before being converted to a raw byte slice.
 
 To install the library, use the following:
 
-	go get -u github.com/tmthrgd/go-bindata
+	go get -u github.com/tmthrgd/go-bindata/...
 
 ### Accessing an asset
 


### PR DESCRIPTION
Previous installation instruction yields following result:

    $ go get -u -v github.com/tmthrgd/go-bindata
    github.com/tmthrgd/go-bindata (download)
    github.com/tmthrgd/go-bindata/internal/identifier
    github.com/tmthrgd/go-bindata

    $ which go-bindata
    go-bindata not found

Adding ... fixes the problem since all dependencies are taken into account:

    $ go get -u -v github.com/tmthrgd/go-bindata/...
    github.com/tmthrgd/go-bindata (download)
    github.com/tmthrgd/go-bindata/chain
    github.com/tmthrgd/go-bindata/go-bindata
    github.com/tmthrgd/go-bindata/restore
    github.com/tmthrgd/go-bindata/vendor/github.com/golang/gddo/httputil/header
    github.com/tmthrgd/go-bindata/httpasset

    $ which go-bindata
    /Users/david/go/bin/go-bindata

Tested with:

    $ go version
    go version go1.8.3 darwin/amd64